### PR TITLE
Add CI pipeline for Kernel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Install QEMU
-      run: sudo apt install qemu qemu-kvm libvirt bridge-utils
+      run: sudo apt install qemu
     - name: Switch to Nightly
       run: rustup default nightly
     - name: Add llvm-tools component


### PR DESCRIPTION
Runs kernel unit tests. Should start running integration tests without modification automatically as well, but there are none yet.