### PR TITLE
interrupt: Provide initial implementation.

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,0 +1,28 @@
+use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use crate::println;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref IDT: InterruptDescriptorTable = {
+        let mut idt = InterruptDescriptorTable::new();
+        idt.breakpoint.set_handler_fn(breakpoint_handler);
+        idt
+    };
+}
+
+pub fn init_idt() {
+    IDT.load();
+}
+
+extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFrame) {
+    println!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
+}
+
+mod tests {
+    use super::*;
+
+    #[test_case]
+    fn test_breakpoint_exception() {
+        x86_64::instructions::interrupts::int3();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,37 @@
 #![no_std]
 #![cfg_attr(test, no_main)]
+#![feature(abi_x86_interrupt)]
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
 pub mod serial;
 pub mod vga_buffer;
+pub mod interrupts;
 
 use core::panic::PanicInfo;
 
+pub fn init() {
+    interrupts::init_idt();
+}
+
+/// Entry point for `cargo test`
+#[cfg(test)]
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    init();
+    test_main();
+    loop {}
+}
+
 pub trait Testable {
     fn run(&self) -> ();
+}
+
+#[cfg(test)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
 }
 
 impl<T> Testable for T
@@ -37,20 +58,6 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
     serial_println!("Error: {}\n", info);
     exit_qemu(QemuExitCode::Failed);
     loop {}
-}
-
-/// Entry point for `cargo test`
-#[cfg(test)]
-#[no_mangle]
-pub extern "C" fn _start() -> ! {
-    test_main();
-    loop {}
-}
-
-#[cfg(test)]
-#[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
-    test_panic_handler(info)
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,15 @@ use kernel::println;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     println!("Hello World{}", "!");
+
+    kernel::init();
+
+    x86_64::instructions::interrupts::int3();
+
     #[cfg(test)]
     test_main();
 
+    println!("It did not crash!");
     loop {}
 }
 


### PR DESCRIPTION
The initial implementation of interrupts and exceptions takes a
bit of a shortcut by using the x86_64 crate and the unstable
x86-interrupt function ABI interface.

The x86_64 package provides an implementation of the interrupt
descriptor table. We can provide a handler function reference
to an implementation of the exception handler for that exception.
