### PR TITLE
Paging: Implement page fault handler.

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,10 +1,11 @@
 use crate::gdt;
+use crate::hlt_loop;
 use crate::print;
 use crate::println;
 use lazy_static::lazy_static;
 use pic8259_simple::ChainedPics;
 use spin;
-use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
+use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
 
 // For reference:
 //                     ____________                          ____________
@@ -37,6 +38,7 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
+        idt.page_fault.set_handler_fn(page_fault_handler);
         idt[InterruptIndex::Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
         idt[InterruptIndex::Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
         idt
@@ -111,6 +113,20 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut Interrup
         PICS.lock()
             .notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
     }
+}
+
+extern "x86-interrupt" fn page_fault_handler(
+    stack_frame: &mut InterruptStackFrame,
+    error_code: PageFaultErrorCode,
+) {
+    // This register will contain the offending address on page fault.
+    use x86_64::registers::control::Cr2;
+
+    println!("EXCEPTION: PAGE FAULT");
+    println!("Accessed Address: {:?}", Cr2::read());
+    println!("Error Code: {:?}", error_code);
+    println!("{:#?}", stack_frame);
+    hlt_loop();
 }
 
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,11 @@ pub extern "C" fn _start() -> ! {
 
     kernel::init();
 
+    use x86_64::registers::control::Cr3;
+
+    let (level_4_page_table, _) = Cr3::read();
+    println!("Level 4 page table at: {:?}", level_4_page_table.start_address());
+
     println!("We did not crash!");
     #[cfg(test)]
         test_main();


### PR DESCRIPTION
The page fault handler will print a debug message to VGA detailing the
offending address. Not very complicated at the moment, however this will
be used in the future to implement writing out pages to spinning rust
when physical RAM is exhausted.

This is a pretty nice abstraction normally, however this is required
when writing an x86_64 operating system.
